### PR TITLE
Add Francis meteorologist profile page

### DIFF
--- a/css/francis.css
+++ b/css/francis.css
@@ -1,0 +1,141 @@
+:root {
+  --bg: #0b1d2a;
+  --card: #ffffff;
+  --accent: #00a8e8;
+  --text: #f4f8fb;
+  --dark-text: #1b2b38;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  background: linear-gradient(180deg, #eaf4ff 0%, #d6ebff 100%);
+  color: var(--dark-text);
+}
+
+.hero {
+  background: linear-gradient(160deg, rgba(11, 29, 42, 0.96), rgba(23, 62, 88, 0.9)),
+    url("../images/headerimg.jpg") center/cover;
+  color: var(--text);
+  padding: 1.25rem 6vw 5rem;
+}
+
+.top-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.top-nav ul {
+  display: flex;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.top-nav a {
+  color: var(--text);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.logo {
+  font-size: 1.2rem;
+}
+
+.hero-content {
+  max-width: 650px;
+  margin-top: 4rem;
+}
+
+.badge {
+  display: inline-block;
+  background: rgba(0, 168, 232, 0.18);
+  border: 1px solid rgba(0, 168, 232, 0.5);
+  color: #b7ebff;
+  border-radius: 999px;
+  padding: 0.4rem 0.85rem;
+}
+
+h1 {
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  margin: 0.8rem 0;
+}
+
+.intro {
+  font-size: 1.1rem;
+  line-height: 1.6;
+}
+
+.button {
+  display: inline-block;
+  background: var(--accent);
+  color: #fff;
+  text-decoration: none;
+  border-radius: 8px;
+  padding: 0.75rem 1.2rem;
+  margin-top: 1rem;
+  font-weight: 700;
+}
+
+main {
+  width: min(1050px, 92vw);
+  margin: -2.2rem auto 0;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: var(--card);
+  border-radius: 12px;
+  padding: 1.3rem;
+  box-shadow: 0 12px 32px rgba(9, 29, 43, 0.1);
+}
+
+.feature-image {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.feature-image img {
+  max-width: 100%;
+  border-radius: 8px;
+}
+
+.highlights,
+.contact {
+  background: #fff;
+  margin-top: 1rem;
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(8, 32, 50, 0.1);
+  padding: 1.5rem;
+}
+
+.highlight-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.highlight-items h3 {
+  color: #05618d;
+  margin-bottom: 0.2rem;
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 1rem;
+  color: #355062;
+}

--- a/francis.html
+++ b/francis.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Francis Storm | Meteorologist Profile</title>
+  <link rel="stylesheet" href="css/francis.css">
+</head>
+<body>
+  <header class="hero">
+    <nav class="top-nav">
+      <a class="logo" href="#home">Francis Storm</a>
+      <ul>
+        <li><a href="#about">About</a></li>
+        <li><a href="#highlights">Highlights</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+
+    <div class="hero-content" id="home">
+      <p class="badge">Chief Weather Anchor</p>
+      <h1>Forecasting with Clarity, Calm, and Confidence.</h1>
+      <p class="intro">Francis has spent 12+ years helping families prepare for everything from sunny weekends to severe storm warnings.</p>
+      <a class="button" href="#contact">Book Francis</a>
+    </div>
+  </header>
+
+  <main>
+    <section id="about" class="card-grid">
+      <article class="card">
+        <h2>About Francis</h2>
+        <p>Francis Storm is a broadcast meteorologist known for clear explanations and accurate regional forecasting. He specializes in severe weather tracking, hurricane readiness, and climate communication.</p>
+        <p>He believes weather reports should be practical and easy for everyone to understand.</p>
+      </article>
+
+      <article class="card feature-image">
+        <img src="images/worldweather.png" alt="World weather map visual">
+      </article>
+    </section>
+
+    <section id="highlights" class="highlights">
+      <h2>Career Highlights</h2>
+      <div class="highlight-items">
+        <div>
+          <h3>1,500+</h3>
+          <p>Live forecasts delivered</p>
+        </div>
+        <div>
+          <h3>12 Years</h3>
+          <p>Broadcast meteorology experience</p>
+        </div>
+        <div>
+          <h3>24/7</h3>
+          <p>Severe weather alert coverage</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="contact" class="contact">
+      <h2>Contact Francis</h2>
+      <p>Available for TV appearances, school weather talks, and emergency preparedness campaigns.</p>
+      <a href="mailto:francis.weather@example.com" class="button">francis.weather@example.com</a>
+    </section>
+  </main>
+
+  <footer>
+    <p>© 2026 Francis Storm Weather Media</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a simple, branded profile site for a weather presenter named Francis to showcase experience and contact information.
- Integrate the new profile into the existing site aesthetic by reusing local weather imagery and consistent styling.

### Description
- Added `francis.html`, a single-page profile containing a hero, about section, career highlights, and contact call-to-action with in-page navigation.
- Added `css/francis.css` which implements the weather-themed hero, responsive card grid, highlight metrics, and CTA button styles.
- Reused existing local assets `images/headerimg.jpg` and `images/worldweather.png` for the hero background and feature image to match repository visuals.

### Testing
- Started a local static server with `python3 -m http.server 4173` and confirmed HTTP 200 responses for `/francis.html` and referenced assets.
- Ran a Playwright script that loaded `http://127.0.0.1:4173/francis.html` and captured a full-page screenshot successfully.
- Verified the screenshot artifact `artifacts/francis-profile.png` to confirm the page rendered as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997cf769024832eb2c17fdf264d4c79)